### PR TITLE
Properties that unify with the expected type, if no matches are found…

### DIFF
--- a/src/be/resolve/macros/Resolver.hx
+++ b/src/be/resolve/macros/Resolver.hx
@@ -1064,6 +1064,10 @@ class Resolver {
 
                             }
 
+                        } else if (signature.unify(module)) {
+                            // Compatible types should just pass thru.
+                            result = e;
+
                         } else {
                             Context.fatalError( NoMatches, e.pos );
 

--- a/tests/Entry.hx
+++ b/tests/Entry.hx
@@ -36,6 +36,7 @@ class Entry {
             new resolver.AbsInstancePropertySpec(),
             new resolver.AbsStaticPropertySpec(),
             new resolver.GenericPropertySpec(),
+            new PassThrough(),
         ])).handle( Runner.exit );
     }
 

--- a/tests/PassThrough.hx
+++ b/tests/PassThrough.hx
@@ -1,0 +1,24 @@
+package ;
+
+import be.types.Resolve;
+
+@:asserts
+class PassThrough {
+
+    public function new() {}
+
+    public function test() {
+        var string = 'hello world';
+        var singleType:Resolve<String> = string;
+
+        asserts.assert( singleType == string );
+
+        var method = function (v:String):String return '$v$v';
+        var funcType:Resolve<String->String> = method;
+
+        asserts.assert( funcType(string) == string + string );
+
+        return asserts.done();
+    }
+
+}


### PR DESCRIPTION
…, should just pass thru.